### PR TITLE
Fix tab header overflow on status bar

### DIFF
--- a/app/src/main/java/oyvindbs/zotshelf/MainActivity.java
+++ b/app/src/main/java/oyvindbs/zotshelf/MainActivity.java
@@ -10,6 +10,9 @@ import android.app.AlertDialog;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.graphics.Insets;
 import androidx.viewpager2.widget.ViewPager2;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -46,6 +49,22 @@ public class MainActivity extends AppCompatActivity {
         tabLayout = findViewById(R.id.tabLayout);
         viewPager = findViewById(R.id.viewPager);
         fabAddTab = findViewById(R.id.fabAddTab);
+
+        // Handle window insets to prevent tab headers from overlapping with status bar
+        View rootView = findViewById(android.R.id.content);
+        ViewCompat.setOnApplyWindowInsetsListener(rootView, (v, windowInsets) -> {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+
+            // Apply top inset to tab layout to prevent overlap with status bar
+            tabLayout.setPadding(
+                tabLayout.getPaddingLeft(),
+                insets.top,
+                tabLayout.getPaddingRight(),
+                tabLayout.getPaddingBottom()
+            );
+
+            return windowInsets;
+        });
 
         // Setup tabs regardless of credentials (fragments will handle empty state)
         setupTabs();

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context=".MainActivity">
 
     <com.google.android.material.tabs.TabLayout


### PR DESCRIPTION
- Add fitsSystemWindows to root layout to respect system UI
- Implement window insets listener to add proper top padding to TabLayout
- Prevents tab headers from overlapping with status bar on devices with notches and different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)