### PR TITLE
Read OAuth credentials from local.properties for Android Studio builds

### DIFF
--- a/OAUTH_SETUP.md
+++ b/OAUTH_SETUP.md
@@ -66,14 +66,14 @@ $env:ZOTERO_OAUTH_CLIENT_SECRET="your_actual_client_secret"
 gradlew.bat build
 ```
 
-**Or create a local.properties file (not committed to git):**
+**Or add the credentials to `local.properties` in the project root (not committed to git):**
 ```properties
-# Add to .gitignore
 ZOTERO_OAUTH_CLIENT_KEY=your_actual_client_key
 ZOTERO_OAUTH_CLIENT_SECRET=your_actual_client_secret
 ```
 
-Then modify `app/build.gradle` to read from local.properties if environment variables aren't set.
+`app/build.gradle` reads these automatically when the environment variables aren't set,
+so this is the easiest option for building from Android Studio.
 
 ### Step 3: How It Works
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,18 @@ plugins {
     id 'com.android.application'
 }
 
+// OAuth credentials: read from environment variables (CI secrets) first,
+// falling back to local.properties (not committed to git) for IDE builds.
+def localProperties = new Properties()
+def localPropertiesFile = rootProject.file('local.properties')
+if (localPropertiesFile.exists()) {
+    localPropertiesFile.withInputStream { localProperties.load(it) }
+}
+
+def oauthSecret = { String name, String placeholder ->
+    System.getenv(name) ?: localProperties.getProperty(name) ?: placeholder
+}
+
 android {
     namespace 'oyvindbs.zotshelf'
 
@@ -14,10 +26,8 @@ android {
         versionCode 120
         versionName "1.2cb"
 
-        // OAuth credentials from environment variables (Bitrise secrets)
-        // Fallback to placeholder values for local development
-        buildConfigField "String", "ZOTERO_OAUTH_CLIENT_KEY", "\"${System.getenv('ZOTERO_OAUTH_CLIENT_KEY') ?: 'YOUR_CLIENT_KEY_HERE'}\""
-        buildConfigField "String", "ZOTERO_OAUTH_CLIENT_SECRET", "\"${System.getenv('ZOTERO_OAUTH_CLIENT_SECRET') ?: 'YOUR_CLIENT_SECRET_HERE'}\""
+        buildConfigField "String", "ZOTERO_OAUTH_CLIENT_KEY", "\"${oauthSecret('ZOTERO_OAUTH_CLIENT_KEY', 'YOUR_CLIENT_KEY_HERE')}\""
+        buildConfigField "String", "ZOTERO_OAUTH_CLIENT_SECRET", "\"${oauthSecret('ZOTERO_OAUTH_CLIENT_SECRET', 'YOUR_CLIENT_SECRET_HERE')}\""
     }
 
     testOptions {


### PR DESCRIPTION
## Summary

Fixes the "OAuth not configured" error when logging in with an APK built from Android Studio.

The OAuth client key/secret were only read from environment variables, which works for CI (Bitrise/GitHub Actions secrets) but not for IDE builds — locally built APKs shipped with the `YOUR_CLIENT_KEY_HERE` placeholder, so the login screen failed immediately.

## Changes

- `app/build.gradle` now falls back to reading `ZOTERO_OAUTH_CLIENT_KEY` and `ZOTERO_OAUTH_CLIENT_SECRET` from `local.properties` (gitignored) when the environment variables are not set
- Environment variables still take precedence, so CI builds are unaffected
- Updated `OAUTH_SETUP.md` to document the now-working `local.properties` option

## Usage

Add to `local.properties` in the project root (alongside `sdk.dir`), then rebuild:

```properties
ZOTERO_OAUTH_CLIENT_KEY=your_actual_client_key
ZOTERO_OAUTH_CLIENT_SECRET=your_actual_client_secret
```

https://claude.ai/code/session_014zx5nPqKh1nnpV7r7qbhC9

---
_Generated by [Claude Code](https://claude.ai/code/session_014zx5nPqKh1nnpV7r7qbhC9)_